### PR TITLE
Run trusted Windows build for ZIP Image to PDF 2.0

### DIFF
--- a/BUILD_REQUEST.txt
+++ b/BUILD_REQUEST.txt
@@ -1,0 +1,2 @@
+Build requested: 2026-06-23
+Target: ZIP Image to PDF 2.0, Windows x64, single-file EXE


### PR DESCRIPTION
Triggers the Windows workflow already present on the default branch. Expected output: a verified Windows x64 single-file executable and its SHA-256 record.